### PR TITLE
explicitly set c++ standard to use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,9 @@ qt4_add_resources(RC_SRCS
   ${RC}
 )
 
+#explicitly set c++ standard to use
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++98")
+
 #flags to set in debug mode
 set (CMAKE_CXX_FLAGS_DEBUG "-g")
 


### PR DESCRIPTION
New C++11 standard is started to be used by default on some distros (e.g. arch). In order to avoid any problems with building on these distros, C++ standard flag should be set explicitly to c++98. 